### PR TITLE
Add root redirect and static web UI for five-minute adventure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # gittest
+
+A five-minute, D&D-style adventure you can play in the terminal or the browser.
+
+## Run in the terminal
+
+```bash
+python3 dnd_five_minute.py
+```
+
+## Run in the browser
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000` in your browser.

--- a/dnd_five_minute.py
+++ b/dnd_five_minute.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+import random
+import textwrap
+
+def roll_die(sides=20):
+    return random.randint(1, sides)
+
+
+def print_wrapped(text):
+    print(textwrap.fill(text, width=78))
+
+
+def choose(prompt, options):
+    while True:
+        print_wrapped(prompt)
+        for key, label in options.items():
+            print(f"  [{key}] {label}")
+        choice = input("> ").strip().lower()
+        if choice in options:
+            return choice
+        print("Please choose one of the listed options.\n")
+
+
+def build_character():
+    print_wrapped(
+        "Welcome to the Five-Minute D&D Adventure! Choose a hero archetype."
+    )
+    options = {
+        "f": "Fighter (steady damage, can shrug off one bad roll)",
+        "r": "Rogue (extra damage on stealthy choices)",
+        "m": "Mage (can reroll a spell once per game)",
+    }
+    choice = choose("Pick your hero:", options)
+    if choice == "f":
+        return {"name": "Fighter", "boon": "guard", "reroll": False}
+    if choice == "r":
+        return {"name": "Rogue", "boon": "sneak", "reroll": False}
+    return {"name": "Mage", "boon": "spell", "reroll": True}
+
+
+def resolve_check(hero, difficulty, bonus=0, allow_reroll=False):
+    roll = roll_die()
+    total = roll + bonus
+    if allow_reroll and hero["reroll"] and total < difficulty:
+        print("Your arcane focus hums. You may reroll once!")
+        hero["reroll"] = False
+        roll = roll_die()
+        total = roll + bonus
+    print(f"You roll a d20: {roll} (total {total} vs {difficulty}).")
+    return total >= difficulty
+
+
+def encounter_one(hero):
+    print_wrapped(
+        "A ruined watchtower blocks the forest path. A goblin lookout peers down."
+    )
+    options = {
+        "a": "Charge the stairs",
+        "b": "Sneak through the brush",
+        "c": "Cast a distracting cantrip",
+    }
+    choice = choose("How do you handle the lookout?", options)
+    bonus = 2 if choice == "a" and hero["name"] == "Fighter" else 0
+    bonus += 3 if choice == "b" and hero["name"] == "Rogue" else 0
+    bonus += 3 if choice == "c" and hero["name"] == "Mage" else 0
+    success = resolve_check(hero, 12, bonus, allow_reroll=(choice == "c"))
+    if success:
+        print_wrapped(
+            "You slip past the goblin and find a pouch of healing herbs. Gain 1 boon."
+        )
+        return 1
+    print_wrapped(
+        "The goblin spots you, and the alarm is raised. You lose time and courage."
+    )
+    return -1
+
+
+def encounter_two(hero):
+    print_wrapped(
+        "A rickety bridge spans a chasm. The ropes creak with every step."
+    )
+    options = {
+        "a": "Cross carefully",
+        "b": "Dash across",
+        "c": "Find a safer route",
+    }
+    choice = choose("What is your approach?", options)
+    bonus = 2 if choice == "a" and hero["name"] == "Fighter" else 0
+    bonus += 2 if choice == "b" and hero["name"] == "Rogue" else 0
+    bonus += 2 if choice == "c" and hero["name"] == "Mage" else 0
+    success = resolve_check(hero, 13, bonus)
+    if success:
+        print_wrapped(
+            "You cross safely and spot a glinting gem lodged in the planks."
+        )
+        return 1
+    print_wrapped(
+        "You stumble, losing your pack. It's gone into the depths."
+    )
+    return -1
+
+
+def encounter_three(hero):
+    print_wrapped(
+        "A wounded wolf blocks the trail, growling yet limping."
+    )
+    options = {
+        "a": "Calm it with rations",
+        "b": "Threaten it away",
+        "c": "Heal it with magic",
+    }
+    choice = choose("How do you deal with the wolf?", options)
+    bonus = 2 if choice == "a" and hero["name"] == "Fighter" else 0
+    bonus += 3 if choice == "b" and hero["name"] == "Rogue" else 0
+    bonus += 4 if choice == "c" and hero["name"] == "Mage" else 0
+    success = resolve_check(hero, 11, bonus, allow_reroll=(choice == "c"))
+    if success:
+        print_wrapped(
+            "The wolf calms and pads away, revealing a hidden cache of coins."
+        )
+        return 1
+    print_wrapped(
+        "The wolf snaps and you withdraw, losing precious time."
+    )
+    return -1
+
+
+def encounter_four(hero):
+    print_wrapped(
+        "You enter the ruined shrine. An enchanted door bars the relic chamber."
+    )
+    options = {
+        "a": "Force it open",
+        "b": "Pick the lock",
+        "c": "Decipher the runes",
+    }
+    choice = choose("How do you breach the door?", options)
+    bonus = 3 if choice == "a" and hero["name"] == "Fighter" else 0
+    bonus += 3 if choice == "b" and hero["name"] == "Rogue" else 0
+    bonus += 3 if choice == "c" and hero["name"] == "Mage" else 0
+    success = resolve_check(hero, 14, bonus)
+    if success:
+        print_wrapped(
+            "The door yields. Inside, you find the relic on a pedestal."
+        )
+        return 1
+    print_wrapped(
+        "The door resists. You lose momentum and feel the pressure of time."
+    )
+    return -1
+
+
+def encounter_five(hero, score):
+    print_wrapped(
+        "The relic is guarded by a spectral knight who demands a final challenge."
+    )
+    options = {
+        "a": "Duel with honor",
+        "b": "Outwit with a feint",
+        "c": "Channel raw magic",
+    }
+    choice = choose("What is your final gambit?", options)
+    bonus = 4 if choice == "a" and hero["name"] == "Fighter" else 0
+    bonus += 4 if choice == "b" and hero["name"] == "Rogue" else 0
+    bonus += 4 if choice == "c" and hero["name"] == "Mage" else 0
+    difficulty = 12 + max(0, 2 - score)
+    success = resolve_check(hero, difficulty, bonus, allow_reroll=(choice == "c"))
+    if success:
+        print_wrapped(
+            "The knight salutes and lets you pass. You claim the relic and escape!"
+        )
+        return True
+    print_wrapped(
+        "The knight blocks your path. You flee with your life, but not the relic."
+    )
+    return False
+
+
+def main():
+    random.seed()
+    hero = build_character()
+    print_wrapped(f"You are the {hero['name']} on a five-minute quest.")
+    print()
+
+    score = 0
+    score += encounter_one(hero)
+    print()
+    score += encounter_two(hero)
+    print()
+    score += encounter_three(hero)
+    print()
+    score += encounter_four(hero)
+    print()
+
+    print_wrapped(f"Your momentum score is {score}. The finale begins.")
+    print()
+    victory = encounter_five(hero, score)
+
+    print()
+    if victory:
+        print_wrapped(
+            "Victory! Your story spreads through the taverns. Thanks for playing."
+        )
+    else:
+        print_wrapped(
+            "Defeat, but not disgrace. Rest up and try the adventure again."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0; url=web/index.html" />
+    <title>五分鐘 D&D 小冒險</title>
+    <style>
+      body {
+        font-family: "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif;
+        background: #f6f2ec;
+        color: #2b251f;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+      }
+
+      .card {
+        background: #fff;
+        padding: 24px 32px;
+        border-radius: 16px;
+        box-shadow: 0 12px 24px rgba(43, 37, 31, 0.08);
+        text-align: center;
+      }
+
+      a {
+        color: #c66f25;
+        font-weight: 600;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>五分鐘 D&D 小冒險</h1>
+      <p>正在導向冒險畫面…</p>
+      <p>若沒有自動跳轉，請點擊 <a href="web/index.html">這裡</a>。</p>
+    </div>
+  </body>
+</html>

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,331 @@
+const heroChoices = [
+  {
+    id: "fighter",
+    name: "戰士",
+    description: "穩定輸出，可在一次失敗檢定後 +2 修正。",
+    bonus: { force: 2 },
+    perk: "guard",
+  },
+  {
+    id: "rogue",
+    name: "盜賊",
+    description: "擅長詭計與潛行，特定行動 +3 修正。",
+    bonus: { sneak: 3 },
+    perk: "sneak",
+  },
+  {
+    id: "mage",
+    name: "法師",
+    description: "可以重擲一次魔法檢定。",
+    bonus: { spell: 3 },
+    perk: "reroll",
+  },
+];
+
+const encounters = [
+  {
+    title: "廢棄哨塔",
+    text: "森林中的哨塔阻擋前路，一名哥布林在上方巡邏。",
+    difficulty: 12,
+    choices: [
+      {
+        label: "衝上階梯正面突破",
+        key: "force",
+        outcome: {
+          success: "你強勢突入，還順手找到一包治療草。",
+          fail: "警報大作，你的時間被拖延。",
+        },
+      },
+      {
+        label: "從灌木間潛行穿過",
+        key: "sneak",
+        outcome: {
+          success: "你悄然通過並搜出一枚幸運符。",
+          fail: "樹枝作響，哥布林警覺了。",
+        },
+      },
+      {
+        label: "施放幻術吸引注意",
+        key: "spell",
+        outcome: {
+          success: "幻術生效，你無聲通過。",
+          fail: "法術失焦，你被迫撤退。",
+        },
+      },
+    ],
+  },
+  {
+    title: "搖晃吊橋",
+    text: "吊橋連接峽谷兩端，木板嘎吱作響。",
+    difficulty: 13,
+    choices: [
+      {
+        label: "穩定步伐慢慢通過",
+        key: "force",
+        outcome: {
+          success: "你成功跨越，還撿到一顆閃亮寶石。",
+          fail: "你滑了一跤，背包掉進深谷。",
+        },
+      },
+      {
+        label: "加速衝刺過去",
+        key: "sneak",
+        outcome: {
+          success: "你迅速通過，沒有觸發陷阱。",
+          fail: "橋身劇烈搖晃，你不得不停下。",
+        },
+      },
+      {
+        label: "尋找繞行路線",
+        key: "spell",
+        outcome: {
+          success: "你找到安全路徑，節省不少力氣。",
+          fail: "你迷失方向，浪費時間。",
+        },
+      },
+    ],
+  },
+  {
+    title: "受傷的狼",
+    text: "一頭受傷的狼擋住道路，低吼卻無力。",
+    difficulty: 11,
+    choices: [
+      {
+        label: "以食物安撫牠",
+        key: "force",
+        outcome: {
+          success: "狼平靜下來，讓出一條道路。",
+          fail: "狼仍保持警戒，你不得不退後。",
+        },
+      },
+      {
+        label: "以威嚇逼退",
+        key: "sneak",
+        outcome: {
+          success: "你成功嚇退牠，找到藏匿的銅幣。",
+          fail: "狼沒有退卻，你失去先機。",
+        },
+      },
+      {
+        label: "用魔法治療",
+        key: "spell",
+        outcome: {
+          success: "魔法安撫了牠，牠帶你到一處藏寶處。",
+          fail: "魔法失效，狼仍戒備。",
+        },
+      },
+    ],
+  },
+  {
+    title: "遺跡之門",
+    text: "你抵達破損神殿，魔法封印之門擋住去路。",
+    difficulty: 14,
+    choices: [
+      {
+        label: "用力量撬開",
+        key: "force",
+        outcome: {
+          success: "門被你撬開，房間內光芒閃動。",
+          fail: "你用力過猛，結界反彈。",
+        },
+      },
+      {
+        label: "拆解鎖頭",
+        key: "sneak",
+        outcome: {
+          success: "你熟練開鎖，門扉敞開。",
+          fail: "機關發出聲響，時間被拖延。",
+        },
+      },
+      {
+        label: "解讀符文",
+        key: "spell",
+        outcome: {
+          success: "你解開符文，力量逐漸消散。",
+          fail: "符文反制你，你被迫後退。",
+        },
+      },
+    ],
+  },
+];
+
+const finale = {
+  title: "幽魂騎士",
+  text: "遺物被幽魂騎士守護，你必須完成最後考驗。",
+  baseDifficulty: 12,
+  choices: [
+    {
+      label: "正面決鬥",
+      key: "force",
+      success: "騎士致意，你成功取回遺物！",
+      fail: "騎士的劍勢太快，你被迫撤退。",
+    },
+    {
+      label: "巧妙詐術",
+      key: "sneak",
+      success: "你的假動作奏效，騎士讓路。",
+      fail: "騎士看穿你的意圖。",
+    },
+    {
+      label: "集中魔力",
+      key: "spell",
+      success: "魔力爆發，幽魂消散。",
+      fail: "魔力不足，你被擊退。",
+    },
+  ],
+};
+
+const state = {
+  hero: null,
+  momentum: 0,
+  encounterIndex: 0,
+  rerollAvailable: false,
+};
+
+const heroName = document.getElementById("hero-name");
+const momentumValue = document.getElementById("momentum");
+const lastRoll = document.getElementById("last-roll");
+const logList = document.getElementById("log");
+const introPanel = document.getElementById("intro-panel");
+const encounterPanel = document.getElementById("encounter-panel");
+const resultPanel = document.getElementById("result-panel");
+const encounterTitle = document.getElementById("encounter-title");
+const encounterText = document.getElementById("encounter-text");
+const encounterChoices = document.getElementById("encounter-choices");
+const heroChoiceContainer = document.getElementById("hero-choices");
+const resultTitle = document.getElementById("result-title");
+const resultText = document.getElementById("result-text");
+const restartButton = document.getElementById("restart");
+
+const rollD20 = () => Math.floor(Math.random() * 20) + 1;
+
+const updateStats = () => {
+  heroName.textContent = state.hero ? state.hero.name : "尚未選擇";
+  momentumValue.textContent = state.momentum;
+};
+
+const addLog = (message) => {
+  const item = document.createElement("li");
+  item.textContent = message;
+  logList.prepend(item);
+};
+
+const resolveCheck = ({ difficulty, bonus, allowReroll }) => {
+  let roll = rollD20();
+  let total = roll + bonus;
+  if (allowReroll && state.rerollAvailable && total < difficulty) {
+    addLog("法師的重擲能力啟動！再擲一次。 ");
+    state.rerollAvailable = false;
+    roll = rollD20();
+    total = roll + bonus;
+  }
+  lastRoll.textContent = `${roll} (+${bonus}) = ${total}`;
+  return total >= difficulty;
+};
+
+const renderEncounter = () => {
+  const encounter = encounters[state.encounterIndex];
+  encounterTitle.textContent = encounter.title;
+  encounterText.textContent = encounter.text;
+  encounterChoices.innerHTML = "";
+  encounter.choices.forEach((choice) => {
+    const button = document.createElement("button");
+    button.textContent = choice.label;
+    button.addEventListener("click", () => handleChoice(encounter, choice));
+    encounterChoices.appendChild(button);
+  });
+};
+
+const renderFinale = () => {
+  encounterTitle.textContent = finale.title;
+  encounterText.textContent = `${finale.text} 目前動能：${state.momentum}`;
+  encounterChoices.innerHTML = "";
+  finale.choices.forEach((choice) => {
+    const button = document.createElement("button");
+    button.textContent = choice.label;
+    button.addEventListener("click", () => handleFinale(choice));
+    encounterChoices.appendChild(button);
+  });
+};
+
+const handleChoice = (encounter, choice) => {
+  const bonus = state.hero.bonus[choice.key] || 0;
+  const allowReroll = choice.key === "spell" && state.hero.perk === "reroll";
+  const success = resolveCheck({
+    difficulty: encounter.difficulty,
+    bonus,
+    allowReroll,
+  });
+
+  if (success) {
+    state.momentum += 1;
+    addLog(choice.outcome.success);
+  } else {
+    state.momentum -= 1;
+    addLog(choice.outcome.fail);
+    if (state.hero.perk === "guard" && state.momentum < 0) {
+      addLog("戰士的護衛直覺啟動，動能不會低於 0。 ");
+      state.momentum = 0;
+    }
+  }
+
+  updateStats();
+  state.encounterIndex += 1;
+
+  if (state.encounterIndex >= encounters.length) {
+    renderFinale();
+  } else {
+    renderEncounter();
+  }
+};
+
+const handleFinale = (choice) => {
+  const bonus = state.hero.bonus[choice.key] || 0;
+  const difficulty = finale.baseDifficulty + Math.max(0, 2 - state.momentum);
+  const allowReroll = choice.key === "spell" && state.hero.perk === "reroll";
+  const success = resolveCheck({ difficulty, bonus, allowReroll });
+
+  encounterPanel.classList.add("hidden");
+  resultPanel.classList.remove("hidden");
+  resultTitle.textContent = success ? "勝利！" : "失敗";
+  resultText.textContent = success
+    ? choice.success
+    : choice.fail + " 你只能帶著經驗退回。";
+};
+
+const startAdventure = (hero) => {
+  state.hero = hero;
+  state.momentum = 0;
+  state.encounterIndex = 0;
+  state.rerollAvailable = hero.perk === "reroll";
+  logList.innerHTML = "";
+  lastRoll.textContent = "-";
+  addLog(`你選擇了 ${hero.name}。冒險開始！`);
+  updateStats();
+  introPanel.classList.add("hidden");
+  resultPanel.classList.add("hidden");
+  encounterPanel.classList.remove("hidden");
+  renderEncounter();
+};
+
+const renderHeroChoices = () => {
+  heroChoiceContainer.innerHTML = "";
+  heroChoices.forEach((hero) => {
+    const button = document.createElement("button");
+    button.classList.add("primary");
+    button.textContent = `${hero.name}｜${hero.description}`;
+    button.addEventListener("click", () => startAdventure(hero));
+    heroChoiceContainer.appendChild(button);
+  });
+};
+
+restartButton.addEventListener("click", () => {
+  introPanel.classList.remove("hidden");
+  encounterPanel.classList.add("hidden");
+  resultPanel.classList.add("hidden");
+  logList.innerHTML = "";
+  lastRoll.textContent = "-";
+});
+
+renderHeroChoices();
+updateStats();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>五分鐘 D&D 小冒險</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="hero">
+        <div>
+          <p class="tag">五分鐘桌遊</p>
+          <h1>五分鐘 D&D 小冒險</h1>
+          <p class="subtitle">
+            在五分鐘內完成一趟短篇冒險，擲骰、做選擇、奪回遺物。
+          </p>
+        </div>
+        <div class="stats">
+          <div>
+            <span class="label">英雄</span>
+            <strong id="hero-name">尚未選擇</strong>
+          </div>
+          <div>
+            <span class="label">動能</span>
+            <strong id="momentum">0</strong>
+          </div>
+          <div>
+            <span class="label">擲骰</span>
+            <strong id="last-roll">-</strong>
+          </div>
+        </div>
+      </header>
+
+      <section class="panel" id="intro-panel">
+        <h2>選擇你的英雄</h2>
+        <p>每位英雄都有不同優勢與一次性能力。</p>
+        <div class="choices" id="hero-choices"></div>
+      </section>
+
+      <section class="panel hidden" id="encounter-panel">
+        <h2 id="encounter-title">冒險開始</h2>
+        <p id="encounter-text"></p>
+        <div class="choices" id="encounter-choices"></div>
+      </section>
+
+      <section class="panel hidden" id="result-panel">
+        <h2 id="result-title">冒險結束</h2>
+        <p id="result-text"></p>
+        <button class="primary" id="restart">再玩一次</button>
+      </section>
+
+      <section class="panel log">
+        <h2>冒險紀錄</h2>
+        <ul id="log"></ul>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif;
+  background: #f6f2ec;
+  color: #2b251f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px 0 64px;
+}
+
+.app {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: grid;
+  gap: 24px;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  background: #fff;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(43, 37, 31, 0.08);
+}
+
+.tag {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #b66b22;
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  margin: 0;
+  color: #5f554c;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  min-width: 260px;
+}
+
+.stats div {
+  background: #fdf9f4;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #eadfce;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 0.75rem;
+  color: #7a6b5f;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.panel {
+  background: #fff;
+  padding: 24px;
+  border-radius: 16px;
+  box-shadow: 0 10px 20px rgba(43, 37, 31, 0.08);
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.choices {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+button {
+  border: none;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: #efe3d4;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  text-align: left;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(43, 37, 31, 0.12);
+}
+
+button.primary {
+  background: #c66f25;
+  color: #fff;
+  font-weight: 600;
+}
+
+.hidden {
+  display: none;
+}
+
+.log ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #5b5147;
+}
+
+.log li + li {
+  margin-top: 6px;
+}


### PR DESCRIPTION
### Motivation
- Make the browser-hosted adventure accessible from the repository root by adding a redirect page. 
- Provide both a terminal play option and a localized, static web frontend to demonstrate the same game mechanics in a browser.
- Surface the hero perks and momentum mechanics (including the Mage reroll and Fighter guard) in an interactive UI.

### Description
- Add a root redirect page `index.html` that forwards visitors to `web/index.html` and includes a localized landing card.
- Add a static web frontend under `web/` containing `web/index.html`, `web/styles.css`, and `web/app.js` which implement hero selection, encounter flow, momentum tracking, roll display, and a log.
- Add a terminal playable script `dnd_five_minute.py` implementing the same encounters and finale logic as the web UI.
- Update `README.md` with instructions for running the terminal and browser versions (`python3 dnd_five_minute.py` and `python3 -m http.server 8000`).

### Testing
- Served the repo root with `python3 -m http.server 8000` and verified the server responded at `http://localhost:8000`.
- Ran a Playwright script to visit the local server and capture a screenshot which produced the artifact `artifacts/dnd_web_root.png`, and the script completed successfully.
- No automated unit tests were added for the static assets; behavior was validated via the static server and the Playwright run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c85d459108328aa9844129d9837f6)